### PR TITLE
feat(variables)!: CLI argument rework

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -71,24 +71,25 @@ commands:
 
 ### Command-Line Arguments
 
-All variable values can be overridden using command-line arguments.
-By default, the name of the argument will be the same as the variable name, so a variable called `name` can be overridden using the `--name` argument.
-
-The optional `argument` and `description` fields can be used to control how the command-line argument is generated for a variable.
-The name of the command-line argument can be overridden using the `argument` field.
-The `description` field can be used to provide help text for the help output.
-Both of these fields are available on all variable types.
+Variable values can be provided using command-line arguments.
+Use the `argument` field to control how the command-line argument is generated for a variable.
+Here, a long name can be specified, along with an optional short name and description.
+The short name can only be one character long.
 
 ```yaml
 variables:
   name:
     value: Dingus
-    description: The name of the user to greet
-    argument: user
-  
+    argument:
+      description: The name of the user to greet
+      name: user
+      short: n
+
   age:
     value: 42
-    desc: The age of the user to greet
+    argument:
+      desc: The age of the user to greet
+      name: age
 
 commands:
   greet:
@@ -106,9 +107,68 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-      --user <user>  The name of the user to greet [default: Dingus]
+  -n  --user <user>  The name of the user to greet [default: Dingus]
       --age <age>    The age of the user to greet [default: 42]
   -h, --help         Print help
+```
+
+The `argument` field also accepts a string if a short name and description are not necessary.
+
+```yaml
+variables:
+  name:
+    value: Dingus
+    argument: user
+    
+commands:
+  greet:
+    description: Greet the user
+    action: echo "Hello, $name!"
+```
+
+```
+$ dingus --help
+Usage: dingus [OPTIONS] <COMMAND>
+
+Commands:
+  greet    Greet the user
+  version  Shows version information
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --user <user>  [default: Dingus]
+  -h, --help         Print help
+```
+
+Positional arguments can also be configured using the `position` field. This will set the position of the argument starting from `1`.
+When the `position` field is used, the `short` field is ignored.
+
+```yaml
+commands:
+  deploy:
+    variables:
+      nodes:
+        value: "5"
+        arg: nodes
+
+      environment:
+        value: Production
+        arg:
+          name: environment
+          position: 1
+
+    action: ...
+```
+
+```
+Usage: dingus deploy [OPTIONS] [environment]
+
+Arguments:
+  [environment]  [default: Production]
+
+Options:
+      --nodes <nodes>  [default: 5]
+  -h, --help           Print help
 ```
 
 ### Literal Variables
@@ -120,13 +180,12 @@ This value can still be overridden using its relevant command-line argument.
 variables:
     name:
         value: dingus
-        description: The name of the user to use
         argument: user
 ```
 
 #### Shorthand
 
-If a description and argument name are not required, literal variables can be shortened to `key: value`.
+If the `argument` field is not required, literal variables can be shortened to `key: value`.
 
 ```yaml
 variables:
@@ -373,23 +432,19 @@ Below are some examples of raw executions vs. bash executions.
 ```yaml
 variables:
     raw_name:
-        desc: Execution variable using a raw execution
         execute: cat example.txt
     
     bash_name:
-        desc: Execution variable using bash
         execute:
             sh: cat example.json | jq -r '.name'
 
     raw_option:
-        desc: Prompt options sourced from a raw execution
         prompt: 
             message: Pick one
             options:
                 execute: cat example.txt
     
     bash_option:
-        desc: Prompt options sourced using a bash command
         prompt:
             message: Pick one
             options:

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -82,7 +82,7 @@ variables:
     value: Dingus
     argument:
       description: The name of the user to greet
-      name: user
+      long: user
       short: n
 
   age:
@@ -141,7 +141,7 @@ Options:
 ```
 
 Positional arguments can also be configured using the `position` field. This will set the position of the argument starting from `1`.
-When the `position` field is used, the `short` field is ignored.
+When the `position` field is used, the `long` and `short` fields cannot be specified.
 
 ```yaml
 commands:
@@ -154,7 +154,7 @@ commands:
       environment:
         value: Production
         arg:
-          name: environment
+          long: environment
           position: 1
 
     action: ...

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,8 @@
 use crate::args::ALIAS_ARGS_NAME;
 use crate::config::{
     ActionConfig, ArgumentConfigVariant, CommandConfig, CommandConfigMap, Config, DingusOptions,
-    ExecutionConfigVariant, NamedArgumentConfig, RawCommandConfigVariant,
-    VariableConfig, VariableConfigMap,
+    ExecutionConfigVariant, NamedArgumentConfig, RawCommandConfigVariant, VariableConfig,
+    VariableConfigMap,
 };
 use crate::platform::{is_current_platform, PlatformProvider};
 use clap::{Arg, ArgMatches, Command, ValueHint};
@@ -248,6 +248,7 @@ type SubcommandSearchResult = (CommandConfig, VariableConfigMap, ArgMatches);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ArgumentConfigVariant::Named;
     use crate::config::OneOrManyPlatforms::{Many, One};
     use crate::config::RawCommandConfigVariant::Shorthand;
     use crate::config::{
@@ -255,7 +256,6 @@ mod tests {
         LiteralVariableConfig, ManyPlatforms, OnePlatform, Platform, PositionalArgumentConfig,
         PromptConfig, PromptVariableConfig, SingleActionConfig, VariableConfig,
     };
-    use crate::config::ArgumentConfigVariant::Named;
     use crate::platform::MockPlatformProvider;
 
     fn mock_platform_provider() -> Box<dyn PlatformProvider> {
@@ -367,7 +367,7 @@ mod tests {
                 argument: Some(ArgumentConfigVariant::Named(NamedArgumentConfig {
                     description: Some("Sub arg 2".to_string()),
                     long: "sub-arg-2".to_string(),
-                    short: None
+                    short: None,
                 })),
                 environment_variable_name: None,
                 prompt: PromptConfig {
@@ -444,10 +444,7 @@ mod tests {
             .find(|arg| arg.get_id() == "sub-var-2")
             .unwrap();
         assert_eq!(sub_arg_2.get_long().unwrap(), "sub-arg-2");
-        assert_eq!(
-            sub_arg_2.get_help().unwrap().to_string(),
-            "Sub arg 2"
-        );
+        assert_eq!(sub_arg_2.get_help().unwrap().to_string(), "Sub arg 2");
     }
 
     #[test]
@@ -457,10 +454,10 @@ mod tests {
         subsubcommand_variables.insert(
             "sub-var-2".to_string(),
             VariableConfig::Prompt(PromptVariableConfig {
-                argument: Some(ArgumentConfigVariant::Named(NamedArgumentConfig{
+                argument: Some(ArgumentConfigVariant::Named(NamedArgumentConfig {
                     description: Some("Sub arg 2".to_string()),
                     long: "sub-arg-2".to_string(),
-                    short: None
+                    short: None,
                 })),
                 environment_variable_name: None,
                 prompt: PromptConfig {
@@ -540,20 +537,14 @@ mod tests {
             .find(|arg| arg.get_id() == "sub-var-1")
             .unwrap();
         assert_eq!(parent_arg.get_long().unwrap(), "sub-arg-1");
-        assert_eq!(
-            parent_arg.get_help(),
-            None
-        );
+        assert_eq!(parent_arg.get_help(), None);
 
         let subcommand_arg = subcommand_args
             .iter()
             .find(|arg| arg.get_id() == "sub-var-2")
             .unwrap();
         assert_eq!(subcommand_arg.get_long().unwrap(), "sub-arg-2");
-        assert_eq!(
-            subcommand_arg.get_help().unwrap().to_string(),
-            "Sub arg 2"
-        );
+        assert_eq!(subcommand_arg.get_help().unwrap().to_string(), "Sub arg 2");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,7 +281,7 @@ pub enum VariableConfig {
     Prompt(PromptVariableConfig),
 
     /// Encapsulates a [`ArgumentVariableConfig`].
-    Argument(ArgumentVariableConfig)
+    Argument(ArgumentVariableConfig),
 }
 
 impl VariableConfig {
@@ -293,7 +293,9 @@ impl VariableConfig {
                 execution_conf.clone().environment_variable_name
             }
             VariableConfig::Prompt(prompt_conf) => prompt_conf.clone().environment_variable_name,
-            VariableConfig::Argument(argument_conf) => argument_conf.clone().environment_variable_name,
+            VariableConfig::Argument(argument_conf) => {
+                argument_conf.clone().environment_variable_name
+            }
         }
         .unwrap_or(key.to_string())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,26 +409,34 @@ pub struct PromptVariableConfig {
     pub prompt: PromptConfig,
 }
 
-/// The kind of `ArgumentConfig`.
+/// The kind of argument configuration.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(untagged)]
 pub enum ArgumentConfigVariant {
     Shorthand(String),
-    Full(ArgumentConfig),
+    Named(NamedArgumentConfig),
+    Positional(PositionalArgumentConfig)
 }
 
 /// The configuration for a command-line argument.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub struct ArgumentConfig {
-    /// The name of the argument.
-    pub name: String,
+pub struct NamedArgumentConfig {
+    /// The long version of the argument without the preceding `--`.
+    pub long: String,
 
-    /// The shortened argument.
+    /// The short version of the argument without the preceding `-`.
     pub short: Option<char>,
+}
+
+/// The configuration for a positional command-line argument.
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct PositionalArgumentConfig {
 
     /// The position of the argument.
-    /// If specified, the argument will be positional.
-    pub position: Option<usize>,
+    /// This refers to position according to other positional argument.
+    /// It does not define the position in the argument list as a whole.
+    /// https://docs.rs/clap/latest/clap/struct.Arg.html#method.index
+    pub position: usize,
 }
 
 /// The configuration for a prompt to the user for input.
@@ -796,7 +804,7 @@ commands:
                     bash: echo \"My command value\"
                 description: Command level variable
                 arg:
-                    name: command-arg-2
+                    long: command-arg-2
                     short: c
                 env: MY_VAR_2
             my-command-var-3:
@@ -804,7 +812,6 @@ commands:
                     bash: echo \"My command value\"
                 description: Command level variable
                 arg:
-                    name: command-arg-3
                     position: 1
                 env: MY_VAR_3
         action: echo \"Hello, World!\"";
@@ -843,10 +850,9 @@ commands:
             &VariableConfig::Execution(ExecutionVariableConfig {
                 execution: bash_exec("echo \"My command value\"", None),
                 description: Some("Command level variable".to_string()),
-                argument: Some(ArgumentConfigVariant::Full(ArgumentConfig {
-                    name: "command-arg-2".to_string(),
+                argument: Some(ArgumentConfigVariant::Named(NamedArgumentConfig {
+                    long: "command-arg-2".to_string(),
                     short: Some('c'),
-                    position: None,
                 })),
                 environment_variable_name: Some("MY_VAR_2".to_string()),
             })
@@ -858,10 +864,8 @@ commands:
             &VariableConfig::Execution(ExecutionVariableConfig {
                 execution: bash_exec("echo \"My command value\"", None),
                 description: Some("Command level variable".to_string()),
-                argument: Some(ArgumentConfigVariant::Full(ArgumentConfig {
-                    name: "command-arg-3".to_string(),
-                    short: None,
-                    position: Some(1),
+                argument: Some(ArgumentConfigVariant::Positional(PositionalArgumentConfig {
+                    position: 1,
                 })),
                 environment_variable_name: Some("MY_VAR_3".to_string()),
             })

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -289,7 +289,6 @@ mod tests {
             name.to_string(),
             VariableConfig::Literal(LiteralVariableConfig {
                 value: value.to_string(),
-                description: None,
                 argument: None,
                 environment_variable_name: None,
             }),
@@ -338,7 +337,6 @@ mod tests {
         variable_configs.insert(
             name.to_string(),
             VariableConfig::Execution(ExecutionVariableConfig {
-                description: None,
                 argument: None,
                 environment_variable_name: None,
                 execution: ExecutionConfigVariant::ShellCommand(ShellCommandConfigVariant::Bash(
@@ -391,7 +389,6 @@ mod tests {
         variable_configs.insert(
             name.to_string(),
             Prompt(PromptVariableConfig {
-                description: None,
                 argument: None,
                 environment_variable_name: None,
                 prompt: PromptConfig {
@@ -442,7 +439,6 @@ mod tests {
         variable_configs.insert(
             name.to_string(),
             Prompt(PromptVariableConfig {
-                description: None,
                 argument: None,
                 environment_variable_name: None,
                 prompt: PromptConfig {
@@ -496,7 +492,6 @@ mod tests {
             name.to_string(),
             VariableConfig::Literal(LiteralVariableConfig {
                 value: value.to_string(),
-                description: None,
                 argument: None,
                 environment_variable_name: Some(env_var_name.to_string()),
             }),

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -36,15 +36,13 @@ impl VariableResolver for RealVariableResolver {
         let mut sensitive_variable_names: Vec<String> = vec![];
 
         for (key, config) in variable_configs.iter() {
-            // Args from the command-line have the highest priority, check there first.
-            let arg_name = config.arg_name(key);
-
             let name = config.environment_variable_name(key);
 
-            if let Some(arg_value) = self.argument_resolver.get(&arg_name) {
+            // Args from the command-line have the highest priority, check there first.
+            if let Some(arg_value) = self.argument_resolver.get(key) {
                 resolved_variables.insert(name.clone(), arg_value.clone());
             } else {
-                _ = match config {
+                match config {
                     VariableConfig::ShorthandLiteral(value) => {
                         resolved_variables.insert(name.clone(), value.clone());
                     }
@@ -292,7 +290,7 @@ mod tests {
             VariableConfig::Literal(LiteralVariableConfig {
                 value: value.to_string(),
                 description: None,
-                argument_name: None,
+                argument: None,
                 environment_variable_name: None,
             }),
         );
@@ -341,7 +339,7 @@ mod tests {
             name.to_string(),
             VariableConfig::Execution(ExecutionVariableConfig {
                 description: None,
-                argument_name: None,
+                argument: None,
                 environment_variable_name: None,
                 execution: ExecutionConfigVariant::ShellCommand(ShellCommandConfigVariant::Bash(
                     BashCommandConfig {
@@ -394,7 +392,7 @@ mod tests {
             name.to_string(),
             Prompt(PromptVariableConfig {
                 description: None,
-                argument_name: None,
+                argument: None,
                 environment_variable_name: None,
                 prompt: PromptConfig {
                     message: "Enter your name".to_string(),
@@ -445,7 +443,7 @@ mod tests {
             name.to_string(),
             Prompt(PromptVariableConfig {
                 description: None,
-                argument_name: None,
+                argument: None,
                 environment_variable_name: None,
                 prompt: PromptConfig {
                     message: "Select your name".to_string(),
@@ -499,7 +497,7 @@ mod tests {
             VariableConfig::Literal(LiteralVariableConfig {
                 value: value.to_string(),
                 description: None,
-                argument_name: None,
+                argument: None,
                 environment_variable_name: Some(env_var_name.to_string()),
             }),
         );

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -97,6 +97,9 @@ impl VariableResolver for RealVariableResolver {
                             sensitive_variable_names.push(name.clone());
                         }
                     }
+
+                    // Arguments are checked above, nothing to do here.
+                    VariableConfig::Argument(_) => {}
                 }
             }
         }
@@ -129,13 +132,11 @@ impl RealVariableResolver {
 
 fn is_variable_sensitive(variable_config: &VariableConfig) -> bool {
     match variable_config {
-        VariableConfig::ShorthandLiteral(_) => false,
-        VariableConfig::Literal(_) => false,
-        VariableConfig::Execution(_) => false,
         VariableConfig::Prompt(prompt_variable) => match prompt_variable.clone().prompt.options {
             PromptOptionsVariant::Select(_) => false,
             PromptOptionsVariant::Text(text_prompt_options) => text_prompt_options.sensitive,
         },
+        _ => false,
     }
 }
 


### PR DESCRIPTION
Re-works CLI arguments to be off by default.
CLI arguments can be created using the `argument` field (`arg` for short).
Here, a `name`, `short` (optional), and `position` (optional) can be specified.

To revert to the previous behaviour where all variables have a corresponding CLI argument, enable the `auto_args` option using the `DINGUS_AUTO_ARGS` environment variable, or by enabling it in the `options` section:

```yaml
options:
  auto_args: true
```